### PR TITLE
Fix ChaikaReports CI policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Go CI/CD Pipeline
 on:
   push:
     branches:
-      - CKR-*
+      - CHR-*
       - CHOPS-*
       - fix/*
   pull_request:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the continuous integration pipeline configuration to trigger on pushes to branches following a new naming pattern, ensuring builds run on the correct branches. Other branch patterns remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->