### PR TITLE
fix: check and pass version from other stage

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,10 +10,31 @@ on:
       - 'completed'
 
 jobs:
+  checkout:
+    name: Checkout code and check ver
+    runs-on: ubuntu-latest
+    outputs:
+      version_modified: ${{ steps.check-version.outputs.version_modified }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check if version was modified
+        id: check-version
+        run: |
+          if git diff --name-only HEAD~1 HEAD | grep -q "version"; then
+              echo "version_modified=true" >> $GITHUB_OUTPUT
+          else
+              echo "version_modified=false" >> $GITHUB_OUTPUT
+          fi
+
   deploy:
     name: Push new image into registry
     runs-on: ubuntu-latest
-    if: ${{github.event.workflow_run.conclusion == 'success' && contains(toJson(github.event.workflow_run.head_commit.modified), 'version')}}
+    needs: checkout
+    if: ${{github.event.workflow_run.conclusion == 'success' && needs.checkout.outputs.version_modified == 'true'}}
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved deployment workflow to only trigger deployment when the "version" file has been modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->